### PR TITLE
Fix the failing workflow by changing `APPNAME` to `APP_NAME`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,6 @@ jobs:
             -e SHINY_ACC_NAME=${{secrets.SHINY_ACC_NAME}} 
             -e TOKEN=${{secrets.TOKEN}} 
             -e SECRET=${{secrets.SECRET}} 
-            -e APPNAME=${{secrets.APP_NAME}}
+            -e APP_NAME=${{secrets.APP_NAME}}
             main
           retry_wait_seconds: 10


### PR DESCRIPTION
The GitHub workflow was failing with the following error message.

```
Error: cannot find APP_NAME !
```

This PR fixes the argument in the Dockerfile.