### PR TITLE
Explicitly evaluate the local environmental variable `LOCAL` as a logical variable

### DIFF
--- a/server.R
+++ b/server.R
@@ -67,7 +67,7 @@ shinyServer(function(input, output, session) {
 # DATA LOAD ---------------------------------------------------------------
     
     download.file("https://www.nccde.org/DocumentCenter/View/38959/covidupdate", "saved_data.xlsx", mode = "wb")
-    if(Sys.getenv("LOCAL")){
+    if(Sys.getenv("LOCAL") == TRUE){
         filename <- "test_data_new.xlsx"
         print("LOCAL")
     }else{


### PR DESCRIPTION
This PR explicitly evaluates the local environmental variable `LOCAL` as a logical variable (fixes #6).

The `LOCAL` variable was evaluating whether the string was TRUE. Because of this, the evaluation was failing if the variable was an empty string because it is not interpretable as logical.